### PR TITLE
Add translation to blog and remove /EN from default routes

### DIFF
--- a/app/admin/post.rb
+++ b/app/admin/post.rb
@@ -38,6 +38,7 @@ ActiveAdmin.register Post do
   form do |f|
     f.inputs do
       f.input :published
+      f.input :language, as: :select, collection: I18n.available_locales.map{|lang| lang.to_s}, include_blank: false
       f.input :hero_image
       f.input :hero_image_cache, as: :hidden
       f.input :title

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,7 @@ class Post < ActiveRecord::Base
   mount_uploader :hero_image, PostUploader
 
   scope :published, -> { where(published: true)
+                         .where(language: I18n.locale.to_s)
                          .where('publish_date <= ?', Date.today)
                          .order(publish_date: :desc) }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,9 +18,9 @@ Bundler.require(*Rails.groups)
 module Website
   class Application < Rails::Application
     config.time_zone = 'Brasilia'
-    config.i18n.locale = :'pt-BR'
-    config.i18n.default_locale = :'pt-BR'
-    config.i18n.available_locales = %i(pt-BR en)
+    config.i18n.locale = :en
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = %i(en pt-BR)
     config.i18n.enforce_available_locales = true
     config.generators do |g|
       g.javascripts false

--- a/config/initializers/route_translation.rb
+++ b/config/initializers/route_translation.rb
@@ -1,5 +1,3 @@
 RouteTranslator.config do |config|
-  config.hide_locale = false
-  config.force_locale = true
   config.available_locales = %i(pt-BR en)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,10 +11,9 @@ Rails.application.routes.draw do
     get 'services',  to: 'pages#services', as: :service
     get '404',       to: 'pages#404',      as: :not_found
     post 'contact',  to: 'pages#contact',  as: :contact
-  end
-  # end
 
-  resources :posts, controller: 'blog', path: 'blog', only: [:index, :show]
+    resources :posts, controller: 'blog', path: 'blog', only: [:index, :show]
+  end
 
   # Keep this always at the end of file to grab 404 problems
   get '*path', to: 'pages#404', via: :all

--- a/db/migrate/20160427013800_add_language_to_posts.rb
+++ b/db/migrate/20160427013800_add_language_to_posts.rb
@@ -1,0 +1,5 @@
+class AddLanguageToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :language, :string, default: 'pt-BR'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160314130842) do
+ActiveRecord::Schema.define(version: 20160427013800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,10 +74,11 @@ ActiveRecord::Schema.define(version: 20160314130842) do
     t.integer  "author_id"
     t.string   "meta_title"
     t.string   "meta_description"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.boolean  "published",        default: false
-    t.string   "meta_tags",        default: "",    null: false
+    t.string   "meta_tags",        default: "",      null: false
+    t.string   "language",         default: "pt-BR"
   end
 
   add_index "posts", ["author_id"], name: "index_posts_on_author_id", using: :btree


### PR DESCRIPTION
The main language of the site is now EN-US so all the /EN routes are hidden and just the PT-BR ones will appear.

Also added BLOG urls inside the localized block on routes.
